### PR TITLE
Add parameter for token prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,23 +66,33 @@ The `CDS_UPLOAD` process uploads the files downloaded from Synapse to an AWS S3 
 - Ensure you have access to the necessary containers (`synapseclient`, `awscli`).
 - Ensure you have the appropriate credentials for Synapse and AWS.
 
-### Command
+### Example usage
+
 Run the workflow with the following command:
 
 ```bash
-nextflow run main.nf --input path/to/samplesheet.csv
-```
-
-### Example
-
-```bash
-nextflow run main.nf --input samplesheet.csv
+nextflow run ncihtan/nf-cdstransfer --input path/to/samplesheet.csv
 ```
 
 Using the test profile will use a built in samplesheet. Note that this requires your provided AWS credentials have acccess to the Sage test bucket `s3://htan-cds-transfer-test-bucket`
 
 ```bash
-nextflow run main.nf -profile test
+nextflow run ncihtan/nf-cdstransfer -profile test
+```
+
+To avoid having to reset secrets when moving between destination accounts you can set your secrets
+using a prefix
+
+```bash
+nextflow secrets set MYCREDS_AWS_ACCESS_KEY_ID
+nextflow secrets set MYCREDS_AWS_SECRET_ACCESS_KEY
+nextflow run ncihtan/nf-cdstransfer --aws_secret_prefix MYCREDS
+```
+
+or use a configured profile in which params.aws_secret_prefix is set
+
+```bash
+nextflow run ncihtan/nf-cdstransfer -profile CDS --input samplesheet.csv
 ```
 
 ### Outputs
@@ -93,5 +103,5 @@ nextflow run main.nf -profile test
 The following environment variables should be set with your credentials:
 
 - `SYNAPSE_AUTH_TOKEN`: Synapse authentication token.
-- `CDS_AWS_ACCESS_KEY_ID`: AWS access key ID.
-- `CDS_AWS_SECRET_ACCESS_KEY`: AWS secret access key.
+- `<params.aws_secret_prefix>_AWS_ACCESS_KEY_ID`: AWS access key ID. eg `CDS_AWS_ACCESS_KEY_ID`
+- `<params.aws_secret_prefix>`: AWS secret access key. eg `CDS_AWS_SECRET_ACCESS_KEY`

--- a/main.nf
+++ b/main.nf
@@ -82,8 +82,8 @@ process cds_upload {
 
     input:
     tuple val(meta), path(entity)
-    secret 'CDS_AWS_ACCESS_KEY_ID'
-    secret 'CDS_AWS_SECRET_ACCESS_KEY'
+    secret "${params.aws_secret_prefix}_AWS_ACCESS_KEY_ID"
+    secret "${params.aws_secret_prefix}_AWS_SECRET_ACCESS_KEY"
 
     output:
     tuple val(meta), path(entity)
@@ -92,8 +92,8 @@ process cds_upload {
     script:
     """
     echo "Uploading ${entity} to ${meta.aws_uri}..."
-    AWS_ACCESS_KEY_ID=\$CDS_AWS_ACCESS_KEY_ID \
-    AWS_SECRET_ACCESS_KEY=\$CDS_AWS_SECRET_ACCESS_KEY \
+    AWS_ACCESS_KEY_ID=\$${params.aws_secret_prefix}_AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY=\$${params.aws_secret_prefix}_AWS_SECRET_ACCESS_KEY \
     aws s3 cp $entity $meta.aws_uri ${params.dryrun ? '--dryrun' : ''}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,12 @@ profiles {
         docker.enabled = true
         params.input = 'samplesheet.csv'   // Only provide input for test profile
         params.dryrun = true
+        params.aws_secret_prefix = 'TEST'
+    }
+
+    cds {
+        params.aws_secret_prefix = 'CDS'
+        docker.enabled = true
     }
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,12 +22,12 @@
           "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row.",
           "fa_icon": "fas fa-file-csv"
         },
-        "dryrun": {
-          "type": "boolean",
-          "default": false,
-          "description": "Run the pipeline in dry-run mode",
-          "help_text": "If this parameter is set to true, the pipeline will not transfer any data, but will print out the commands that would be executed. This is useful for testing the pipeline before running it for real.",
-          "fa_icon": "fas fa-flask"
+        "aws_secret_prefix": {
+          "type": "string",
+          "default": "CDS",
+          "description": "Prefix for AWS secrets to be used in the pipeline.",
+          "help_text": "Specify the prefix for AWS secrets, e.g., 'HTAN'. This prefix will be used to load the corresponding AWS access key and secret key from {prefix}_ACCESS_KEY and {prefix}_SECRET_KEY secrets in the Nextflow secrets manager.",
+          "fa_icon": "fas fa-key"
         }
       }
     }

--- a/tower.yaml
+++ b/tower.yaml
@@ -1,3 +1,3 @@
 reports:
-  reports/trace.csv":
+  "**/trace.csv":
     display: "Nextflow trace file"


### PR DESCRIPTION
This pull request includes several updates to the `CDS_UPLOAD` process to enhance flexibility and improve documentation. The changes involve modifying the way AWS credentials are handled and updating the related documentation to reflect these changes.

### Updates to AWS Credentials Handling:

* [`main.nf`](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L85-R86): Updated the `cds_upload` process to use a parameterized AWS secret prefix for accessing AWS credentials. (`[[1]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L85-R86)`, `[[2]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L95-R96)`)
* [`nextflow.config`](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR26-R31): Added profiles for `test` and `cds`, each with a specific AWS secret prefix. (`[nextflow.configR26-R31](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR26-R31)`)
* [`nextflow_schema.json`](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6L25-R30): Introduced a new parameter `aws_secret_prefix` for specifying the prefix for AWS secrets. (`[nextflow_schema.jsonL25-R30](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6L25-R30)`)

### Documentation Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R95): Updated the example usage section to reflect the changes in the command for running the workflow and added instructions for setting AWS secrets using a prefix. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R95)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R107)`)

### Miscellaneous:

* [`tower.yaml`](diffhunk://#diff-755b70d16056c5ae15e53aeb384c49cccec46bef92132ae262cf34ed9a759ed0L2-R2): Corrected the path for the Nextflow trace file in the reports section. (`[tower.yamlL2-R2](diffhunk://#diff-755b70d16056c5ae15e53aeb384c49cccec46bef92132ae262cf34ed9a759ed0L2-R2)`)