### PR TITLE
Allow for bucket name to be switched with change_bucket param

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -23,6 +23,6 @@
         }
       },
       "required": ["entityId", "file_url_in_cds"],
-      "additionalProperties": false
+      "additionalProperties": true
     }
   }

--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,16 @@ ch_input = Channel
     .fromList(samplesheetToList(params.input, "assets/schema_input.json"))
     // Unpack the tuple
     .map { it -> it[0] }
+    // If change_bucket is procided then regex replace the bucket name in aws_uri. eg if change_buckert = bucket2 then s3://bucket1/key1 -> s3://bucket2/key1
+    .map { it ->
+        // Check if `change_bucket` is provided and update `aws_uri` if needed
+        if (params.change_bucket) {
+            it.aws_uri = it.aws_uri.replaceAll("(s3://)[^/]+(/.*)", "\$1${params.change_bucket}\$2")
+        }
+        return it
+    }
+
+ch_input.view()
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,7 @@ ch_input = Channel
     .fromList(samplesheetToList(params.input, "assets/schema_input.json"))
     // Unpack the tuple
     .map { it -> it[0] }
-    // If change_bucket is procided then regex replace the bucket name in aws_uri. eg if change_buckert = bucket2 then s3://bucket1/key1 -> s3://bucket2/key1
+    // If change_bucket is provided then regex replace the bucket name in aws_uri. eg if change_buckert = bucket2 then s3://bucket1/key1 -> s3://bucket2/key1
     .map { it ->
         // Check if `change_bucket` is provided and update `aws_uri` if needed
         if (params.change_bucket) {

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,6 +35,7 @@ profiles {
 params{
     dryrun = false
     take_n = -1
+    params.change_bucket = false
 }
 
 // Consolidate plugins into a single block

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -43,6 +43,13 @@
           "help_text": "Specify the prefix for AWS secrets, e.g., 'HTAN'. This prefix will be used to load the corresponding AWS access key and secret key from {prefix}_ACCESS_KEY and {prefix}_SECRET_KEY secrets in the Nextflow secrets manager.",
           "fa_icon": "fas fa-key"
         }
+        ,
+        "change_bucket": {
+          "type": "string",
+          "description": "Bucket name to replace those in the input file",
+          "help_text": "Replaces the bucket names in the input file with the specified bucket name. This is useful when you want to transfer data to a different bucket than the one specified in the input file.",
+          "fa_icon": "fas fa-bucket"
+        }
       }
     }
   },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -42,8 +42,7 @@
           "description": "Prefix for AWS secrets to be used in the pipeline.",
           "help_text": "Specify the prefix for AWS secrets, e.g., 'HTAN'. This prefix will be used to load the corresponding AWS access key and secret key from {prefix}_ACCESS_KEY and {prefix}_SECRET_KEY secrets in the Nextflow secrets manager.",
           "fa_icon": "fas fa-key"
-        }
-        ,
+        },
         "change_bucket": {
           "type": "string",
           "description": "Bucket name to replace those in the input file",


### PR DESCRIPTION
This pull request introduces changes to support the functionality of replacing bucket names in AWS URIs based on a provided parameter. Additionally, it modifies the schema to allow extra properties and updates the configuration to include the new parameter.

### Schema and Configuration Updates:

* [`assets/schema_input.json`](diffhunk://#diff-dc9c490fc41c232f18648f965bb3bc2ac01dce6611082a2e11594aa6907a647eL26-R26): Changed `additionalProperties` to `true` to allow extra properties in the schema.
* [`nextflow_schema.json`](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R46-R52): Added a new parameter `change_bucket` to the schema, including its type, description, and help text.
* [`nextflow.config`](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR38): Added `change_bucket` parameter to the configuration with a default value of `false`.

### Functional Changes:

* [`main.nf`](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R29-R38): Added logic to replace the bucket name in `aws_uri` if the `change_bucket` parameter is provided.