### PR TITLE
Add stubs for prcesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .nextflow*
 /work
-*.csv
+set_*_creds.sh

--- a/main.nf
+++ b/main.nf
@@ -62,6 +62,13 @@ process synapse_get {
     shopt -s nullglob
     for f in *\\ *; do mv "\${f}" "\${f// /_}"; done  # Rename files with spaces
     """
+
+    stub:
+    """
+    echo "Making a fake file for testing..."
+    ## Make a random file of 1MB and save to small_file.tmp
+    dd if=/dev/urandom of=small_file.tmp bs=1M count=1
+    """
 }
 
 /*
@@ -95,6 +102,11 @@ process cds_upload {
     AWS_ACCESS_KEY_ID=\$${params.aws_secret_prefix}_AWS_ACCESS_KEY_ID \
     AWS_SECRET_ACCESS_KEY=\$${params.aws_secret_prefix}_AWS_SECRET_ACCESS_KEY \
     aws s3 cp $entity $meta.aws_uri ${params.dryrun ? '--dryrun' : ''}
+    """
+
+    stub:
+    """
+    echo "Making a fake upload..."
     """
 }
 

--- a/samplesheet.csv
+++ b/samplesheet.csv
@@ -1,0 +1,6 @@
+entityId,file_url_in_cds
+syn26947830,s3://htan-cds-transfer-test-bucket/test2/test2_object1.png
+syn26947830,s3://htan-cds-transfer-test-bucket/test2/test2_object2.png
+syn26947830,s3://htan-cds-transfer-test-bucket/test2/test2_object3.png
+syn26947830,s3://htan-cds-transfer-test-bucket/test2/test2_object4.png
+syn26947830,s3://htan-cds-transfer-test-bucket/test2/test2_object5.png


### PR DESCRIPTION
This pull request includes changes to add stub sections for testing purposes and updates to the `samplesheet.csv` file. The most important changes are summarized below:

### Additions for Testing:

* [`main.nf`](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R65-R71): Added a stub section in the `synapse_get` process to create a fake file for testing.
* [`main.nf`](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R106-R110): Added a stub section in the `cds_upload` process to simulate a fake upload.

### Updates to CSV File:

* [`samplesheet.csv`](diffhunk://#diff-b532ab00867f067fa641fa8ae8d7d4f61f2da184e495dbd01f14aad6e0f71c19R1-R6): Added multiple entries with `entityId` and `file_url_in_cds` for testing purposes.